### PR TITLE
fixed schedule causing blank webpage

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,13 +4,7 @@ import { Database } from "../lib/db/database.types";
 import { getAllClasses, AllClassesResponse } from "../lib/db/classes";
 import { Class, LoadingClass, sortClasses } from "../components/complete/class";
 import Loading from "../components/misc/loading";
-import {
-	dayPlus,
-	getSchedule,
-	getSchedulesForXDays,
-	ScheduleData,
-	ScheduleInterface,
-} from "../lib/db/schedule";
+import { getSchedulesForXDays, ScheduleInterface } from "../lib/db/schedule";
 import ScheduleComponent from "../components/complete/schedule";
 import { AssignmentPreview } from "../components/complete/assignments";
 import Link from "next/link";


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7a16fe5</samp>

### Summary
🔧🗑️📊

<!--
1.  🔧 - This emoji represents a wrench, which is a common tool for refactoring or fixing code. It suggests that the pull request is mainly focused on improving the existing codebase, rather than adding new features or functionality.
2.  🗑️ - This emoji represents a wastebasket, which is used to dispose of unwanted or unnecessary items. It suggests that the pull request is removing some redundant or unused code, such as the `scheduleTemplates` and `scheduleItems` variables, and making the code more concise and clean.
3.  📊 - This emoji represents a bar chart, which is a common way of visualizing data or information. It suggests that the pull request is modifying the data structure of `schedules`, and making it easier to access and manipulate the schedule data.
-->
Refactor schedule fetching and rendering on `index.tsx`. Simplify `schedules` data structure and remove unused variables.

> _Sing, O Muse, of the skillful refactorer_
> _Who simplified the code for rendering the schedule_
> _No more he needed `scheduleTemplates` or `scheduleItems`_
> _But extracted `schedules` from `fullSchedule` with ease_

### Walkthrough
*  Simplify the data structure for rendering the schedule table on the index page by extracting the schedule array from each schedule day object in the fullSchedule variable ([link](https://github.com/CoursifyStudios/Coursify/pull/111/files?diff=unified&w=0#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3R101-R106))
* Remove the unnecessary code that was appending the schedule templates and the schedule items to the schedules state variable, as they were causing duplicate entries and errors in the schedule table ([link](https://github.com/CoursifyStudios/Coursify/pull/111/files?diff=unified&w=0#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L82-L87), [link](https://github.com/CoursifyStudios/Coursify/pull/111/files?diff=unified&w=0#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L97-L101))


