### PR TITLE
X icon on dark mode

### DIFF
--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -213,7 +213,7 @@ const Navbar: NextComponentType = () => {
 						// I decided to instead just make the text the link. It not great but is just works:tm:
 						// - Lukas
 						className={`ml-2 h-5 w-5 cursor-pointer rounded-sm text-gray-500 transition hover:text-gray-800 dark:text-gray-100
-									 ${selected ? "hover:bg-gray-100" : "hover:bg-gray-400/20"}`}
+									 ${selected ? "hover:bg-gray-200" : "hover:bg-gray-400/20"}`}
 					/>
 				)}
 			</div>


### PR DESCRIPTION
# Overview of PR

_Written_ 📝

<!-- Comments (like this one) do not need to be deleted before merging your pr -->

### Standards

_All need to be completed before marking a pr as ready to review_

- [x] I have reviewed my code and confirmed it doesn't cause any major security issues or create unhandled edge cases (i.e. unhandled errors)
- [x] I have tested my code in production and verified that it works as intended
- [x] I have organized my code based on our brief style guide and made sure that it's rationally componentized
- [x] I have confirmed the pages I edited work on light and dark mode

### Brief Summary

I like changed 3 characters

<img width="536" alt="image" src="https://github.com/CoursifyStudios/Coursify/assets/98719767/55cdce17-d85a-4d4a-9e34-aa4065118594">

## Tabulated Changes

- X button on dark mode no longer shows a white hover

# Details

_Generated by AI_ ✨

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 201f626</samp>

* Increase the contrast of the navbar tabs on hover to improve accessibility and user experience ([link](https://github.com/CoursifyStudios/Coursify/pull/305/files?diff=unified&w=0#diff-2647284034689872359f6518f174a139d4bda55b489c900e7764e74369f3a11eL216-R216))

### Poem

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 201f626</samp>

> _`hover:bg-gray-200`_
> _Contrast for the navbar tabs_
> _Snowy winter sky_

### AI Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 201f626</samp>

Improved the navbar contrast by changing the hover background color in `components/layout/navbar.tsx`. This enhances the accessibility and user experience of the navbar component.
