### PR TITLE
Navbar stuff

### DIFF
--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -36,8 +36,29 @@ const Navbar: NextComponentType = () => {
 				full_name: "Coursify Demo User",
 		  }
 		: user?.user_metadata ?? {};
+	const [username, setUsername] = useState<string>();
+	const [fullname, setFullName] = useState<string>();
 
 	useEffect(() => setHydrated(true), []);
+
+	useEffect(() => {
+		if (username != undefined && fullname != undefined) return;
+		if (user?.id == undefined) return;
+		(async () => {
+			const { data } = await supabase
+				.from("users")
+				.select("full_name")
+				.eq("id", user.id)
+				.single();
+
+			if (data == undefined) {
+				// Some sort of weird edge case that should never happen - Bloxs
+				return;
+			}
+			setUsername(data.full_name);
+			setFullName(data.full_name);
+		})();
+	}, [username, fullname, supabase, user?.id]);
 
 	const logOut = async () => {
 		removeCookie("onboardingState");
@@ -105,13 +126,13 @@ const Navbar: NextComponentType = () => {
 										onClick={() =>
 											newTab(
 												"/profile/1e5024f5-d493-4e32-9822-87f080ad5516",
-												`${userMetadata.name}'s Profile`
+												`${username ?? userMetadata.name}'s Profile`
 											)
 										}
 									>
 										<Menu.Item as="div" className="mx-2 flex flex-col">
 											<h3 className="line-clamp-2 font-medium">
-												{userMetadata.full_name}
+												{fullname ?? userMetadata.full_name}
 											</h3>
 											<p className="truncate text-xs">{userMetadata.email}</p>
 										</Menu.Item>
@@ -122,7 +143,7 @@ const Navbar: NextComponentType = () => {
 										onClick={() =>
 											newTab(
 												`/profile/${user?.id}`,
-												`${userMetadata.name}'s Profile`
+												`${username ?? userMetadata.name}'s Profile`
 											)
 										}
 									>


### PR DESCRIPTION
# Overview of PR

_Written_ 📝

<!-- Comments (like this one) do not need to be deleted before merging your pr -->

### Standards

_All need to be completed before marking a pr as ready to review_

- [x] I have reviewed my code and confirmed it doesn't cause any major security issues or create unhandled edge cases (i.e. unhandled errors)
- [x] I have tested my code in production and verified that it works as intended
- [x] I have organized my code based on our brief style guide and made sure that it's rationally componentized
- [x] I have confirmed the pages I edited work on light and dark mode

### Brief Summary
Closes #189 

## Tabulated Changes
- Sample text

# Details

_Generated by AI_ ✨

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cda8d58</samp>

*  Add state variables and useEffect hook to fetch and store user's name from database ([link](https://github.com/CoursifyStudios/Coursify/pull/316/files?diff=unified&w=0#diff-2647284034689872359f6518f174a139d4bda55b489c900e7764e74369f3a11eL39-R62))
*  Use `username` state variable as fallback for profile tab name in navbar ([link](https://github.com/CoursifyStudios/Coursify/pull/316/files?diff=unified&w=0#diff-2647284034689872359f6518f174a139d4bda55b489c900e7764e74369f3a11eL108-R129), [link](https://github.com/CoursifyStudios/Coursify/pull/316/files?diff=unified&w=0#diff-2647284034689872359f6518f174a139d4bda55b489c900e7764e74369f3a11eL125-R146))
*  Use `fullname` state variable as fallback for menu item name in navbar ([link](https://github.com/CoursifyStudios/Coursify/pull/316/files?diff=unified&w=0#diff-2647284034689872359f6518f174a139d4bda55b489c900e7764e74369f3a11eL114-R135))

### Poem

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cda8d58</samp>

> _`useEffect` fetches_
> _user's name from the database_
> _a spring of changes_

### AI Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cda8d58</samp>

This pull request updates the navbar component to fetch and display the user's name from the database instead of the userMetadata props. This enables the user to see their updated name in the navbar after editing it in their profile settings.
